### PR TITLE
Have added basic config to output SR outputs for val sets to Tensorboard

### DIFF
--- a/codes/train.py
+++ b/codes/train.py
@@ -315,6 +315,12 @@ def fit(model, opt, dataloaders, steps_states, data_params, loggers):
                         img_dir = os.path.join(opt['path']['val_images'], img_name)
                         util.mkdir(img_dir)
 
+                        if opt['use_tb_logger'] and opt['logger']['tb_log_generated']:
+                            tb_logger.add_image(f"Generated (SR) [{img_name}]", visuals['SR'].clamp(0, 1), current_step)
+
+                        if opt['use_tb_logger'] and opt['logger']['tb_log_lr']:
+                            tb_logger.add_image(f"Low Resolution [{img_name}]", visuals['LR'].clamp(0, 1), current_step)
+
                         # Save SR images for reference
                         sr_img = None
                         if hasattr(model, 'heats'):  # SRFlow


### PR DESCRIPTION
This change will allow users to add the configuration variables to the `logger` section to define `tb_log_generated`: true and `tb_log_lr`: true which will then output the same validation images to tensorboard directly for users.

This was something I added purely for my own benefit when training pixel based stuff, and it could be HUGE outputs with loads of validation sets, however there seemed like no sane way to allow users to dictate what validation sets they should output, I thought maybe a sort of `image_log_skip` variable that would let a user specify they only wanted to write out like 1 in every 50 validation images etc.

Anyway feel free to reject, its something I did for BasicSR and now I am doing a little prototype with this newer version I wanted to be able to report my stuff all in TB, so make any alterations you want.

Thanks again for the great library.